### PR TITLE
feat: add backend data models and Pydantic schemas

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,1 +1,55 @@
 """Data models for DocFlow HR."""
+
+from app.models.enums import (
+    UserStatus,
+    EmploymentStatus,
+    DocumentCategory,
+    DocumentStatus,
+    SubmissionChannel,
+    SubmissionStatus,
+    AuditAction,
+    AuditEntityType,
+    LegalHoldStatus,
+    LegalHoldScopeType,
+    RoleType,
+    USState,
+)
+from app.models.base import (
+    ZeroDBBaseModel,
+    TimestampMixin,
+    OrgScopedMixin,
+    SoftDeleteMixin,
+    AuditMetadataMixin,
+    ZeroDBTableSchema,
+)
+from app.models.organization import Organization, OrganizationSettings
+from app.models.user import Permission, Role, User
+
+__all__ = [
+    # Enums
+    "UserStatus",
+    "EmploymentStatus",
+    "DocumentCategory",
+    "DocumentStatus",
+    "SubmissionChannel",
+    "SubmissionStatus",
+    "AuditAction",
+    "AuditEntityType",
+    "LegalHoldStatus",
+    "LegalHoldScopeType",
+    "RoleType",
+    "USState",
+    # Base classes
+    "ZeroDBBaseModel",
+    "TimestampMixin",
+    "OrgScopedMixin",
+    "SoftDeleteMixin",
+    "AuditMetadataMixin",
+    "ZeroDBTableSchema",
+    # Models
+    "Organization",
+    "OrganizationSettings",
+    "Permission",
+    "Role",
+    "User",
+]

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,0 +1,190 @@
+"""Base models for DocFlow HR.
+
+This module provides base Pydantic models with common fields used across
+all entity types. These models define the structure for ZeroDB table schemas.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class ZeroDBBaseModel(BaseModel):
+    """Base model for ZeroDB entities.
+
+    Provides common fields and configuration for all database models.
+    All models inherit timestamp tracking and Pydantic v2 configuration.
+    """
+
+    class Config:
+        """Pydantic model configuration."""
+        from_attributes = True
+        populate_by_name = True
+        json_encoders = {
+            datetime: lambda v: v.isoformat(),
+            UUID: lambda v: str(v),
+        }
+
+
+class TimestampMixin(BaseModel):
+    """Mixin for timestamp tracking.
+
+    Provides created_at and updated_at fields for audit purposes.
+    These fields are automatically set by the database.
+    """
+
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Timestamp when record was created (UTC)",
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Timestamp when record was last updated (UTC)",
+    )
+
+
+class OrgScopedMixin(BaseModel):
+    """Mixin for multi-tenant organization scoping.
+
+    All entities (except organizations themselves) must be scoped to an
+    organization for proper data isolation.
+
+    COMPLIANCE NOTE: Tenant isolation is critical for data privacy.
+    All queries must include org_id filter to prevent data leakage.
+    """
+
+    org_id: UUID = Field(
+        description="Organization ID for multi-tenant isolation",
+    )
+
+
+class SoftDeleteMixin(BaseModel):
+    """Mixin for soft delete support.
+
+    Enables logical deletion while preserving data for audit/compliance.
+    Soft-deleted records are excluded from normal queries but retained
+    for audit trail and potential recovery.
+
+    COMPLIANCE NOTE: Some regulations require retention of deleted records.
+    Physical deletion (hard delete) should only occur per retention policy.
+    """
+
+    deleted_at: Optional[datetime] = Field(
+        default=None,
+        description="Timestamp when record was soft-deleted (NULL if active)",
+    )
+    deleted_by: Optional[UUID] = Field(
+        default=None,
+        description="User ID who performed soft delete",
+    )
+
+
+class AuditMetadataMixin(BaseModel):
+    """Mixin for tracking who created/modified records.
+
+    Provides actor tracking for compliance and audit purposes.
+    """
+
+    created_by: UUID = Field(
+        description="User ID who created this record",
+    )
+    updated_by: UUID = Field(
+        description="User ID who last updated this record",
+    )
+
+
+def generate_uuid() -> UUID:
+    """Generate a new UUID v4.
+
+    Returns:
+        A new UUID v4 identifier.
+    """
+    return uuid4()
+
+
+class ZeroDBTableSchema(BaseModel):
+    """Helper model for defining ZeroDB table schemas.
+
+    This model represents the schema structure expected by ZeroDB's
+    table creation API.
+    """
+
+    columns: list[Dict[str, Any]] = Field(
+        description="List of column definitions",
+    )
+    indexes: Optional[list[Dict[str, Any]]] = Field(
+        default=None,
+        description="List of index definitions",
+    )
+
+    @staticmethod
+    def column_def(
+        name: str,
+        col_type: str,
+        *,
+        primary_key: bool = False,
+        nullable: bool = True,
+        unique: bool = False,
+        default: Any = None,
+        references: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a column definition.
+
+        Args:
+            name: Column name
+            col_type: Column type (uuid, text, integer, boolean, timestamp, jsonb, etc.)
+            primary_key: Whether this is a primary key column
+            nullable: Whether NULL values are allowed
+            unique: Whether values must be unique
+            default: Default value expression
+            references: Foreign key reference (e.g., "organizations(id)")
+
+        Returns:
+            Column definition dictionary
+        """
+        col = {
+            "name": name,
+            "type": col_type,
+            "nullable": nullable,
+        }
+        if primary_key:
+            col["primary_key"] = True
+            col["nullable"] = False  # PKs cannot be null
+        if unique:
+            col["unique"] = True
+        if default is not None:
+            col["default"] = default
+        if references:
+            col["references"] = references
+        return col
+
+    @staticmethod
+    def index_def(
+        name: str,
+        columns: list[str],
+        *,
+        unique: bool = False,
+        where: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create an index definition.
+
+        Args:
+            name: Index name
+            columns: List of column names to index
+            unique: Whether this is a unique index
+            where: Optional WHERE clause for partial index
+
+        Returns:
+            Index definition dictionary
+        """
+        idx = {
+            "name": name,
+            "columns": columns,
+        }
+        if unique:
+            idx["unique"] = True
+        if where:
+            idx["where"] = where
+        return idx

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -1,0 +1,286 @@
+"""Enumeration types for DocFlow HR models.
+
+This module defines all enum types used across the application to ensure
+consistency and type safety. Enums are used for status fields, categories,
+and other controlled vocabularies.
+"""
+
+from enum import Enum
+
+
+class UserStatus(str, Enum):
+    """User account status.
+
+    Controls user access to the system:
+    - ACTIVE: User can log in and access system
+    - INACTIVE: User account disabled, cannot log in
+    - SUSPENDED: Temporarily disabled, pending investigation
+    - PENDING: Account created but not yet activated (email verification)
+    """
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    SUSPENDED = "suspended"
+    PENDING = "pending"
+
+
+class EmploymentStatus(str, Enum):
+    """Employee employment status.
+
+    Tracks employee lifecycle:
+    - ACTIVE: Currently employed, working
+    - TERMINATED: Employment ended (voluntary or involuntary)
+    - ON_LEAVE: Temporarily away (FMLA, medical, personal leave)
+    - SUSPENDED: Disciplinary suspension
+
+    COMPLIANCE NOTE: Status transitions affect document retention requirements.
+    Different states have different final paycheck and document delivery timelines.
+    """
+    ACTIVE = "active"
+    TERMINATED = "terminated"
+    ON_LEAVE = "on_leave"
+    SUSPENDED = "suspended"
+
+
+class DocumentCategory(str, Enum):
+    """Document categories aligned with HR compliance requirements.
+
+    Categories determine:
+    - Retention period requirements
+    - Required review workflows
+    - Privacy/security classification
+    - State-specific regulations
+
+    COMPLIANCE NOTES:
+    - I9: Must be retained for 3 years after hire or 1 year after termination,
+      whichever is later (USCIS requirement)
+    - W4: Required for payroll tax withholding (IRS)
+    - DIRECT_DEPOSIT: Banking information, requires enhanced PII protection
+    - BENEFITS: ERISA compliance, typically 6 years retention
+    - PERFORMANCE: Support for unemployment claims, discipline, termination
+    - POLICY_ACKNOWLEDGMENT: Proof of employee awareness of policies
+    """
+    I9 = "i9"
+    W4 = "w4"
+    DIRECT_DEPOSIT = "direct_deposit"
+    BENEFITS_ENROLLMENT = "benefits_enrollment"
+    PERFORMANCE_REVIEW = "performance_review"
+    DISCIPLINARY_ACTION = "disciplinary_action"
+    TERMINATION = "termination"
+    POLICY_ACKNOWLEDGMENT = "policy_acknowledgment"
+    OTHER = "other"
+
+
+class DocumentStatus(str, Enum):
+    """Document workflow status.
+
+    Tracks document through review and approval lifecycle:
+    - PENDING_REVIEW: Submitted, awaiting HR review
+    - APPROVED: Reviewed and accepted, officially on file
+    - REJECTED: Does not meet requirements, employee must resubmit
+    - EXPIRED: Document has passed expiration date (e.g., I-9 work authorization)
+
+    COMPLIANCE NOTE: Only APPROVED documents satisfy compliance requirements.
+    Rejected/expired documents do not count toward completion of onboarding.
+    """
+    PENDING_REVIEW = "pending_review"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+
+
+class SubmissionChannel(str, Enum):
+    """Channel through which document was submitted.
+
+    Tracks intake method for audit and troubleshooting:
+    - EMAIL: Received via email (parsed from inbox)
+    - WEB_UPLOAD: Direct upload through web portal
+    - MOBILE: Submitted via mobile app
+    - FAX: Legacy fax submission (parsed via fax-to-email)
+    - MAIL: Physical mail, scanned by HR staff
+    - API: Submitted via integration (e.g., from HRIS)
+    """
+    EMAIL = "email"
+    WEB_UPLOAD = "web_upload"
+    MOBILE = "mobile"
+    FAX = "fax"
+    MAIL = "mail"
+    API = "api"
+
+
+class SubmissionStatus(str, Enum):
+    """Submission processing status.
+
+    Tracks intake workflow:
+    - RECEIVED: Submission captured, not yet processed
+    - PROCESSING: Being parsed, validated, matched to employee
+    - MATCHED: Successfully matched to employee record
+    - DOCUMENT_CREATED: Document entity created from submission
+    - FAILED: Processing failed (e.g., could not identify employee)
+    - DUPLICATE: Identical submission already processed
+    """
+    RECEIVED = "received"
+    PROCESSING = "processing"
+    MATCHED = "matched"
+    DOCUMENT_CREATED = "document_created"
+    FAILED = "failed"
+    DUPLICATE = "duplicate"
+
+
+class AuditAction(str, Enum):
+    """Audit event action types.
+
+    Standardized action vocabulary for audit trail.
+    All data mutations must generate an audit event.
+    """
+    CREATED = "created"
+    UPDATED = "updated"
+    DELETED = "deleted"
+    VIEWED = "viewed"
+    DOWNLOADED = "downloaded"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXPORTED = "exported"
+    RESTORED = "restored"
+    PURGED = "purged"
+
+
+class AuditEntityType(str, Enum):
+    """Entity types that can be audited.
+
+    Corresponds to main tables in the system.
+    """
+    ORGANIZATION = "organization"
+    USER = "user"
+    ROLE = "role"
+    EMPLOYEE = "employee"
+    DOCUMENT = "document"
+    DOCUMENT_VERSION = "document_version"
+    SUBMISSION = "submission"
+    LEGAL_HOLD = "legal_hold"
+    RETENTION_POLICY = "retention_policy"
+
+
+class LegalHoldStatus(str, Enum):
+    """Legal hold status.
+
+    Controls retention policy overrides:
+    - ACTIVE: Hold is in effect, documents cannot be purged
+    - RELEASED: Hold has been lifted, normal retention applies
+    - PENDING: Hold created but not yet in effect
+
+    COMPLIANCE NOTE: Documents under legal hold MUST NOT be deleted
+    regardless of retention policy. Spoliation of evidence can result
+    in severe legal penalties.
+    """
+    ACTIVE = "active"
+    RELEASED = "released"
+    PENDING = "pending"
+
+
+class LegalHoldScopeType(str, Enum):
+    """Legal hold scope type.
+
+    Defines what the hold applies to:
+    - EMPLOYEE: All documents for specific employee(s)
+    - DEPARTMENT: All documents for department
+    - DATE_RANGE: All documents within date range
+    - DOCUMENT_CATEGORY: All documents of specific category
+    - CUSTOM: Custom filter criteria in scope_value JSON
+    """
+    EMPLOYEE = "employee"
+    DEPARTMENT = "department"
+    DATE_RANGE = "date_range"
+    DOCUMENT_CATEGORY = "document_category"
+    CUSTOM = "custom"
+
+
+class RoleType(str, Enum):
+    """Standard RBAC role types.
+
+    Predefined roles following least-privilege principles:
+    - SUPER_ADMIN: Full system access (DocFlow platform admin)
+    - ORG_ADMIN: Full access within organization
+    - HR_ADMIN: Full HR operations, can manage employees and documents
+    - HR_GENERALIST: Standard HR operations, limited configuration
+    - PAYROLL_SPECIALIST: Access to payroll-related documents (W-4, direct deposit)
+    - BENEFITS_ADMIN: Access to benefits enrollment documents
+    - HIRING_MANAGER: View employees in their department
+    - EMPLOYEE: Self-service access to own documents
+
+    COMPLIANCE NOTE: Role assignments must be audited. Access to PII
+    (SSN, salary, bank accounts) should be restricted to roles that
+    require it for their job function.
+    """
+    SUPER_ADMIN = "super_admin"
+    ORG_ADMIN = "org_admin"
+    HR_ADMIN = "hr_admin"
+    HR_GENERALIST = "hr_generalist"
+    PAYROLL_SPECIALIST = "payroll_specialist"
+    BENEFITS_ADMIN = "benefits_admin"
+    HIRING_MANAGER = "hiring_manager"
+    EMPLOYEE = "employee"
+
+
+class USState(str, Enum):
+    """US state codes for state-specific compliance.
+
+    State codes are used for:
+    - Retention policy requirements (vary by state)
+    - Final paycheck timing rules
+    - Unemployment claim reporting
+    - State-specific leave laws (CA CFRA, NY Paid Family Leave, etc.)
+
+    COMPLIANCE NOTE: California, New York, and Massachusetts have
+    particularly strict document retention and employee rights laws.
+    """
+    AL = "AL"
+    AK = "AK"
+    AZ = "AZ"
+    AR = "AR"
+    CA = "CA"
+    CO = "CO"
+    CT = "CT"
+    DE = "DE"
+    FL = "FL"
+    GA = "GA"
+    HI = "HI"
+    ID = "ID"
+    IL = "IL"
+    IN = "IN"
+    IA = "IA"
+    KS = "KS"
+    KY = "KY"
+    LA = "LA"
+    ME = "ME"
+    MD = "MD"
+    MA = "MA"
+    MI = "MI"
+    MN = "MN"
+    MS = "MS"
+    MO = "MO"
+    MT = "MT"
+    NE = "NE"
+    NV = "NV"
+    NH = "NH"
+    NJ = "NJ"
+    NM = "NM"
+    NY = "NY"
+    NC = "NC"
+    ND = "ND"
+    OH = "OH"
+    OK = "OK"
+    OR = "OR"
+    PA = "PA"
+    RI = "RI"
+    SC = "SC"
+    SD = "SD"
+    TN = "TN"
+    TX = "TX"
+    UT = "UT"
+    VT = "VT"
+    VA = "VA"
+    WA = "WA"
+    WV = "WV"
+    WI = "WI"
+    WY = "WY"
+    DC = "DC"  # District of Columbia

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -1,0 +1,184 @@
+"""Organization models for multi-tenant architecture.
+
+Organizations represent tenant companies using DocFlow HR.
+All other entities are scoped to an organization for data isolation.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from pydantic import Field, field_validator
+
+from app.models.base import ZeroDBBaseModel, TimestampMixin, ZeroDBTableSchema
+
+
+class OrganizationSettings(ZeroDBBaseModel):
+    """Organization-level settings and configuration.
+
+    These settings control organization-wide behavior and compliance rules.
+    """
+
+    # Document retention defaults
+    default_retention_days: int = Field(
+        default=2555,  # 7 years, common HR document retention
+        description="Default retention period in days for documents without specific policy",
+        ge=1,
+    )
+
+    # Email intake configuration
+    email_intake_enabled: bool = Field(
+        default=True,
+        description="Whether email-based document intake is enabled",
+    )
+    email_intake_addresses: list[str] = Field(
+        default_factory=list,
+        description="Email addresses monitored for document submissions",
+    )
+
+    # Auto-approval settings (use with caution)
+    auto_approve_documents: bool = Field(
+        default=False,
+        description="Whether to auto-approve certain document categories (NOT RECOMMENDED for I-9)",
+    )
+    auto_approve_categories: list[str] = Field(
+        default_factory=list,
+        description="Document categories eligible for auto-approval if enabled",
+    )
+
+    # Notification settings
+    notify_on_new_submission: bool = Field(
+        default=True,
+        description="Send notification to HR when new document submitted",
+    )
+    notification_email: Optional[str] = Field(
+        default=None,
+        description="Email address for HR notifications",
+    )
+
+    # Employee self-service
+    employee_portal_enabled: bool = Field(
+        default=True,
+        description="Whether employees can access self-service portal",
+    )
+
+    # Compliance settings
+    require_i9_within_days: int = Field(
+        default=3,
+        description="Business days to complete I-9 after hire date (USCIS requirement)",
+        ge=1,
+        le=3,  # USCIS mandates completion within 3 business days
+    )
+
+    # Custom fields for organization-specific needs
+    custom_fields: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Custom organization configuration as JSON",
+    )
+
+
+class Organization(ZeroDBBaseModel, TimestampMixin):
+    """Organization (tenant) entity.
+
+    Represents a company/organization using DocFlow HR.
+    Provides multi-tenant isolation for all data.
+
+    COMPLIANCE NOTE: Organization data isolation is critical.
+    Cross-tenant data access is a serious security/privacy violation.
+    """
+
+    id: UUID = Field(
+        description="Unique organization identifier (UUID)",
+    )
+
+    name: str = Field(
+        min_length=1,
+        max_length=255,
+        description="Organization legal name",
+    )
+
+    slug: str = Field(
+        min_length=2,
+        max_length=100,
+        description="URL-safe organization identifier (e.g., 'acme-corp')",
+        pattern=r"^[a-z0-9-]+$",
+    )
+
+    settings: OrganizationSettings = Field(
+        default_factory=OrganizationSettings,
+        description="Organization-level settings and configuration",
+    )
+
+    # Subscription/billing info
+    plan_tier: str = Field(
+        default="free",
+        description="Subscription plan tier (free, starter, professional, enterprise)",
+    )
+
+    is_active: bool = Field(
+        default=True,
+        description="Whether organization account is active",
+    )
+
+    # Contact information
+    primary_contact_email: Optional[str] = Field(
+        default=None,
+        description="Primary contact email for organization",
+    )
+
+    @field_validator("slug")
+    @classmethod
+    def validate_slug(cls, v: str) -> str:
+        """Validate slug is lowercase and URL-safe."""
+        if not v.islower():
+            raise ValueError("Slug must be lowercase")
+        if "--" in v or v.startswith("-") or v.endswith("-"):
+            raise ValueError("Slug cannot start/end with hyphen or contain consecutive hyphens")
+        return v
+
+    @staticmethod
+    def table_schema() -> ZeroDBTableSchema:
+        """Get ZeroDB table schema for organizations.
+
+        Returns:
+            Table schema definition for ZeroDB
+        """
+        return ZeroDBTableSchema(
+            columns=[
+                ZeroDBTableSchema.column_def(
+                    "id", "uuid", primary_key=True, default="gen_random_uuid()"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "name", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "slug", "text", nullable=False, unique=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "settings", "jsonb", nullable=False, default="'{}'::jsonb"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "plan_tier", "text", nullable=False, default="'free'"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "is_active", "boolean", nullable=False, default="true"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "primary_contact_email", "text", nullable=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "created_at", "timestamp", nullable=False, default="now()"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "updated_at", "timestamp", nullable=False, default="now()"
+                ),
+            ],
+            indexes=[
+                ZeroDBTableSchema.index_def(
+                    "idx_organizations_slug", ["slug"], unique=True
+                ),
+                ZeroDBTableSchema.index_def(
+                    "idx_organizations_active", ["is_active"]
+                ),
+            ],
+        )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,349 @@
+"""User and RBAC models for authentication and authorization.
+
+This module implements role-based access control (RBAC) following
+least-privilege principles. All system users must have a role that
+defines their permissions.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import EmailStr, Field, field_validator
+
+from app.models.base import (
+    ZeroDBBaseModel,
+    TimestampMixin,
+    OrgScopedMixin,
+    ZeroDBTableSchema,
+)
+from app.models.enums import UserStatus, RoleType
+
+
+class Permission(ZeroDBBaseModel):
+    """Permission definition for granular access control.
+
+    Permissions follow the pattern: resource:action
+    Examples: employees:read, documents:write, audit:view
+    """
+
+    resource: str = Field(
+        description="Resource type (e.g., 'employees', 'documents', 'audit')",
+    )
+    action: str = Field(
+        description="Action allowed (e.g., 'read', 'write', 'delete', 'approve')",
+    )
+
+    def __str__(self) -> str:
+        """String representation of permission."""
+        return f"{self.resource}:{self.action}"
+
+
+class Role(ZeroDBBaseModel, OrgScopedMixin, TimestampMixin):
+    """Role definition for RBAC.
+
+    Roles group permissions together and are assigned to users.
+    Standard roles are seeded at organization creation, but custom
+    roles can be created for specific needs.
+
+    COMPLIANCE NOTE: Changes to role permissions must be audited.
+    Granting access to PII requires business justification.
+    """
+
+    id: UUID = Field(
+        description="Unique role identifier",
+    )
+
+    name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Role name (e.g., 'HR Admin', 'Payroll Specialist')",
+    )
+
+    role_type: RoleType = Field(
+        description="Standard role type enum",
+    )
+
+    description: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Human-readable description of role purpose and scope",
+    )
+
+    permissions: List[str] = Field(
+        default_factory=list,
+        description="List of permission strings (e.g., ['employees:read', 'documents:write'])",
+    )
+
+    is_system_role: bool = Field(
+        default=False,
+        description="Whether this is a system-defined role (cannot be deleted)",
+    )
+
+    is_active: bool = Field(
+        default=True,
+        description="Whether this role can be assigned to users",
+    )
+
+    @field_validator("permissions")
+    @classmethod
+    def validate_permissions(cls, v: List[str]) -> List[str]:
+        """Validate permission format."""
+        for perm in v:
+            if ":" not in perm:
+                raise ValueError(f"Invalid permission format: {perm}. Must be 'resource:action'")
+            parts = perm.split(":")
+            if len(parts) != 2:
+                raise ValueError(f"Invalid permission format: {perm}. Must be 'resource:action'")
+        return v
+
+    @staticmethod
+    def table_schema() -> ZeroDBTableSchema:
+        """Get ZeroDB table schema for roles.
+
+        Returns:
+            Table schema definition for ZeroDB
+        """
+        return ZeroDBTableSchema(
+            columns=[
+                ZeroDBTableSchema.column_def(
+                    "id", "uuid", primary_key=True, default="gen_random_uuid()"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "org_id", "uuid", nullable=False, references="organizations(id)"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "name", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "role_type", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "description", "text", nullable=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "permissions", "jsonb", nullable=False, default="'[]'::jsonb"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "is_system_role", "boolean", nullable=False, default="false"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "is_active", "boolean", nullable=False, default="true"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "created_at", "timestamp", nullable=False, default="now()"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "updated_at", "timestamp", nullable=False, default="now()"
+                ),
+            ],
+            indexes=[
+                ZeroDBTableSchema.index_def(
+                    "idx_roles_org_id", ["org_id"]
+                ),
+                ZeroDBTableSchema.index_def(
+                    "idx_roles_org_role_type", ["org_id", "role_type"], unique=True
+                ),
+                ZeroDBTableSchema.index_def(
+                    "idx_roles_active", ["org_id", "is_active"]
+                ),
+            ],
+        )
+
+
+class User(ZeroDBBaseModel, OrgScopedMixin, TimestampMixin):
+    """User account for system access.
+
+    Users authenticate to the system and are assigned roles that
+    determine their permissions. Users may also be linked to employee
+    records for self-service access.
+
+    SECURITY NOTES:
+    - Password hashes must never be logged or included in API responses
+    - Failed login attempts should be tracked to prevent brute force
+    - MFA should be required for admin roles
+    - Session tokens should expire and be invalidated on logout
+    """
+
+    id: UUID = Field(
+        description="Unique user identifier",
+    )
+
+    email: EmailStr = Field(
+        description="User email address (used for login)",
+    )
+
+    password_hash: str = Field(
+        description="Bcrypt password hash (NEVER expose in API responses)",
+    )
+
+    first_name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="User first name",
+    )
+
+    last_name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="User last name",
+    )
+
+    status: UserStatus = Field(
+        default=UserStatus.ACTIVE,
+        description="User account status",
+    )
+
+    role_id: UUID = Field(
+        description="Role ID (foreign key to roles table)",
+    )
+
+    # Optional link to employee record (for employee self-service)
+    employee_id: Optional[UUID] = Field(
+        default=None,
+        description="Employee record ID if user is an employee (for self-service)",
+    )
+
+    # Security tracking
+    last_login_at: Optional[datetime] = Field(
+        default=None,
+        description="Timestamp of last successful login",
+    )
+
+    failed_login_attempts: int = Field(
+        default=0,
+        description="Count of consecutive failed login attempts",
+    )
+
+    locked_until: Optional[datetime] = Field(
+        default=None,
+        description="Account locked until this timestamp (after too many failed attempts)",
+    )
+
+    # Email verification
+    email_verified: bool = Field(
+        default=False,
+        description="Whether user has verified their email address",
+    )
+
+    email_verification_token: Optional[str] = Field(
+        default=None,
+        description="Token for email verification (NULL after verification)",
+    )
+
+    # Password reset
+    password_reset_token: Optional[str] = Field(
+        default=None,
+        description="Token for password reset (NULL when not in reset flow)",
+    )
+
+    password_reset_expires: Optional[datetime] = Field(
+        default=None,
+        description="Expiration timestamp for password reset token",
+    )
+
+    # Preferences
+    preferences: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="User preferences and UI settings as JSON",
+    )
+
+    @field_validator("password_hash")
+    @classmethod
+    def validate_password_hash(cls, v: str) -> str:
+        """Validate password hash format (bcrypt)."""
+        if not v.startswith("$2b$") and not v.startswith("$2a$"):
+            raise ValueError("Password hash must be bcrypt format")
+        return v
+
+    @property
+    def full_name(self) -> str:
+        """Get user's full name."""
+        return f"{self.first_name} {self.last_name}"
+
+    @staticmethod
+    def table_schema() -> ZeroDBTableSchema:
+        """Get ZeroDB table schema for users.
+
+        Returns:
+            Table schema definition for ZeroDB
+        """
+        return ZeroDBTableSchema(
+            columns=[
+                ZeroDBTableSchema.column_def(
+                    "id", "uuid", primary_key=True, default="gen_random_uuid()"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "org_id", "uuid", nullable=False, references="organizations(id)"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "email", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "password_hash", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "first_name", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "last_name", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "status", "text", nullable=False, default="'active'"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "role_id", "uuid", nullable=False, references="roles(id)"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "employee_id", "uuid", nullable=True, references="employees(id)"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "last_login_at", "timestamp", nullable=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "failed_login_attempts", "integer", nullable=False, default="0"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "locked_until", "timestamp", nullable=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "email_verified", "boolean", nullable=False, default="false"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "email_verification_token", "text", nullable=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "password_reset_token", "text", nullable=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "password_reset_expires", "timestamp", nullable=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "preferences", "jsonb", nullable=False, default="'{}'::jsonb"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "created_at", "timestamp", nullable=False, default="now()"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "updated_at", "timestamp", nullable=False, default="now()"
+                ),
+            ],
+            indexes=[
+                ZeroDBTableSchema.index_def(
+                    "idx_users_org_id", ["org_id"]
+                ),
+                ZeroDBTableSchema.index_def(
+                    "idx_users_email", ["org_id", "email"], unique=True
+                ),
+                ZeroDBTableSchema.index_def(
+                    "idx_users_role_id", ["role_id"]
+                ),
+                ZeroDBTableSchema.index_def(
+                    "idx_users_employee_id", ["employee_id"],
+                    where="employee_id IS NOT NULL"
+                ),
+                ZeroDBTableSchema.index_def(
+                    "idx_users_status", ["org_id", "status"]
+                ),
+            ],
+        )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -6,10 +6,125 @@ from app.schemas.common import (
     SuccessResponse,
     PaginatedResponse,
 )
+from app.schemas.organizations import (
+    OrganizationCreate,
+    OrganizationUpdate,
+    OrganizationResponse,
+    OrganizationListResponse,
+)
+from app.schemas.users import (
+    UserInviteRequest,
+    UserInviteResponse,
+    UserActivateRequest,
+    UserActivateResponse,
+    UserResponse,
+    UserListResponse,
+)
+from app.schemas.employees import (
+    EmployeeCreate,
+    EmployeeUpdate,
+    EmployeeResponse,
+    EmployeeListResponse,
+    EmployeeSearchQuery,
+)
+from app.schemas.uploads import (
+    UploadRequest,
+    UploadResponse,
+    UploadCompleteRequest,
+    UploadCompleteResponse,
+    FileMetadata,
+)
+from app.schemas.review import (
+    ReviewQueueItem,
+    ReviewQueueResponse,
+    ApproveRequest,
+    RejectRequest,
+    ReviewResponse,
+    ReviewStats,
+)
+from app.schemas.audit import (
+    AuditAction,
+    AuditEntityType,
+    AuditEventCreate,
+    AuditEvent,
+    AuditEventListResponse,
+    AuditEventFilter,
+    DocumentAuditTrailResponse,
+)
+from app.schemas.retention import (
+    RetentionPolicyBase,
+    RetentionPolicyCreate,
+    RetentionPolicy,
+    RetentionCalculation,
+    RetentionScheduleRequest,
+    RetentionScheduleResponse,
+)
+from app.schemas.legal_hold import (
+    LegalHoldScope,
+    LegalHoldCreate,
+    LegalHold,
+    LegalHoldRelease,
+    LegalHoldReleaseResponse,
+    DocumentLegalHoldStatus,
+)
 
 __all__ = [
+    # Common
     "HealthResponse",
     "ErrorResponse",
     "SuccessResponse",
     "PaginatedResponse",
+    # Organizations
+    "OrganizationCreate",
+    "OrganizationUpdate",
+    "OrganizationResponse",
+    "OrganizationListResponse",
+    # Users
+    "UserInviteRequest",
+    "UserInviteResponse",
+    "UserActivateRequest",
+    "UserActivateResponse",
+    "UserResponse",
+    "UserListResponse",
+    # Employees
+    "EmployeeCreate",
+    "EmployeeUpdate",
+    "EmployeeResponse",
+    "EmployeeListResponse",
+    "EmployeeSearchQuery",
+    # Uploads
+    "UploadRequest",
+    "UploadResponse",
+    "UploadCompleteRequest",
+    "UploadCompleteResponse",
+    "FileMetadata",
+    # Review
+    "ReviewQueueItem",
+    "ReviewQueueResponse",
+    "ApproveRequest",
+    "RejectRequest",
+    "ReviewResponse",
+    "ReviewStats",
+    # Audit
+    "AuditAction",
+    "AuditEntityType",
+    "AuditEventCreate",
+    "AuditEvent",
+    "AuditEventListResponse",
+    "AuditEventFilter",
+    "DocumentAuditTrailResponse",
+    # Retention
+    "RetentionPolicyBase",
+    "RetentionPolicyCreate",
+    "RetentionPolicy",
+    "RetentionCalculation",
+    "RetentionScheduleRequest",
+    "RetentionScheduleResponse",
+    # Legal Hold
+    "LegalHoldScope",
+    "LegalHoldCreate",
+    "LegalHold",
+    "LegalHoldRelease",
+    "LegalHoldReleaseResponse",
+    "DocumentLegalHoldStatus",
 ]

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -1,0 +1,181 @@
+"""Pydantic schemas for Audit & Events system."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AuditAction(str, Enum):
+    """Supported audit event action types."""
+
+    # Document events
+    DOCUMENT_RECEIVED = "document.received"
+    DOCUMENT_VERSION_CREATED = "document.version.created"
+    DOCUMENT_REVIEW_APPROVED = "document.review.approved"
+    DOCUMENT_REVIEW_REJECTED = "document.review.rejected"
+
+    # Employee events
+    EMPLOYEE_CREATED = "employee.created"
+    EMPLOYEE_UPDATED = "employee.updated"
+
+    # Legal hold events
+    LEGAL_HOLD_CREATED = "legal_hold.created"
+    LEGAL_HOLD_RELEASED = "legal_hold.released"
+
+
+class AuditEntityType(str, Enum):
+    """Supported audit entity types."""
+
+    DOCUMENT = "document"
+    EMPLOYEE = "employee"
+    LEGAL_HOLD = "legal_hold"
+
+
+class AuditEventCreate(BaseModel):
+    """Schema for creating an audit event."""
+
+    entity_type: str = Field(
+        ...,
+        description="Type of entity being audited (e.g., document, employee, legal_hold)",
+        examples=["document", "employee", "legal_hold"],
+    )
+    entity_id: str = Field(
+        ...,
+        description="Unique identifier of the entity",
+        examples=["doc-123", "emp-456"],
+    )
+    action: str = Field(
+        ...,
+        description="Action performed on the entity",
+        examples=["document.received", "employee.created"],
+    )
+    actor_id: str = Field(
+        ...,
+        description="ID of the user or system performing the action",
+        examples=["user-789", "system"],
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Additional context and details about the event",
+        examples=[{"previous_version": "1.0", "new_version": "1.1"}],
+    )
+
+
+class AuditEvent(BaseModel):
+    """Schema for an audit event response."""
+
+    id: str = Field(
+        ...,
+        description="Unique identifier for the audit event",
+    )
+    org_id: str = Field(
+        ...,
+        description="Organization ID the event belongs to",
+    )
+    entity_type: str = Field(
+        ...,
+        description="Type of entity being audited",
+    )
+    entity_id: str = Field(
+        ...,
+        description="Unique identifier of the entity",
+    )
+    action: str = Field(
+        ...,
+        description="Action performed on the entity",
+    )
+    actor_id: str = Field(
+        ...,
+        description="ID of the user or system performing the action",
+    )
+    actor_email: Optional[str] = Field(
+        default=None,
+        description="Email of the actor (if available)",
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Additional context and details about the event",
+    )
+    created_at: datetime = Field(
+        ...,
+        description="Timestamp when the event was created",
+    )
+
+    class Config:
+        """Pydantic model configuration."""
+
+        from_attributes = True
+
+
+class AuditEventListResponse(BaseModel):
+    """Paginated response for audit events list."""
+
+    events: List[AuditEvent] = Field(
+        ...,
+        description="List of audit events",
+    )
+    total: int = Field(
+        ...,
+        ge=0,
+        description="Total number of events matching the query",
+    )
+    page: int = Field(
+        ...,
+        ge=1,
+        description="Current page number",
+    )
+    page_size: int = Field(
+        ...,
+        ge=1,
+        le=100,
+        description="Number of items per page",
+    )
+
+
+class AuditEventFilter(BaseModel):
+    """Filter parameters for querying audit events."""
+
+    entity_type: Optional[str] = Field(
+        default=None,
+        description="Filter by entity type",
+    )
+    entity_id: Optional[str] = Field(
+        default=None,
+        description="Filter by entity ID",
+    )
+    action: Optional[str] = Field(
+        default=None,
+        description="Filter by action type",
+    )
+    actor_id: Optional[str] = Field(
+        default=None,
+        description="Filter by actor ID",
+    )
+    start_date: Optional[datetime] = Field(
+        default=None,
+        description="Filter events created after this date",
+    )
+    end_date: Optional[datetime] = Field(
+        default=None,
+        description="Filter events created before this date",
+    )
+
+
+class DocumentAuditTrailResponse(BaseModel):
+    """Response for document-specific audit trail."""
+
+    document_id: str = Field(
+        ...,
+        description="ID of the document",
+    )
+    events: List[AuditEvent] = Field(
+        ...,
+        description="List of audit events for this document in chronological order",
+    )
+    total_events: int = Field(
+        ...,
+        ge=0,
+        description="Total number of events for this document",
+    )

--- a/backend/app/schemas/employees.py
+++ b/backend/app/schemas/employees.py
@@ -1,0 +1,223 @@
+"""Pydantic schemas for employee management."""
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field, EmailStr
+
+
+class EmploymentStatus(str, Enum):
+    """Employment status enumeration."""
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    ON_LEAVE = "on_leave"
+    TERMINATED = "terminated"
+    PENDING = "pending"
+
+
+class EmploymentType(str, Enum):
+    """Employment type enumeration."""
+
+    FULL_TIME = "full_time"
+    PART_TIME = "part_time"
+    CONTRACT = "contract"
+    TEMPORARY = "temporary"
+    INTERN = "intern"
+
+
+class EmployeeCreate(BaseModel):
+    """Schema for creating a new employee."""
+
+    employee_number: Optional[str] = Field(
+        default=None,
+        max_length=50,
+        description="Employee ID/number (auto-generated if not provided)"
+    )
+    first_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Employee first name"
+    )
+    last_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Employee last name"
+    )
+    email: EmailStr = Field(
+        ...,
+        description="Employee email address"
+    )
+    phone: Optional[str] = Field(
+        default=None,
+        max_length=20,
+        description="Phone number"
+    )
+    department: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Department name"
+    )
+    job_title: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Job title"
+    )
+    manager_id: Optional[str] = Field(
+        default=None,
+        description="Manager's employee ID"
+    )
+    employment_type: EmploymentType = Field(
+        default=EmploymentType.FULL_TIME,
+        description="Type of employment"
+    )
+    hire_date: Optional[date] = Field(
+        default=None,
+        description="Hire date"
+    )
+    start_date: Optional[date] = Field(
+        default=None,
+        description="Work start date"
+    )
+    location: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Work location"
+    )
+    metadata: Optional[dict] = Field(
+        default_factory=dict,
+        description="Additional employee metadata"
+    )
+
+
+class EmployeeUpdate(BaseModel):
+    """Schema for updating an employee."""
+
+    first_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+        description="Employee first name"
+    )
+    last_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+        description="Employee last name"
+    )
+    email: Optional[EmailStr] = Field(
+        default=None,
+        description="Employee email address"
+    )
+    phone: Optional[str] = Field(
+        default=None,
+        max_length=20,
+        description="Phone number"
+    )
+    department: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Department name"
+    )
+    job_title: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Job title"
+    )
+    manager_id: Optional[str] = Field(
+        default=None,
+        description="Manager's employee ID"
+    )
+    employment_type: Optional[EmploymentType] = Field(
+        default=None,
+        description="Type of employment"
+    )
+    employment_status: Optional[EmploymentStatus] = Field(
+        default=None,
+        description="Employment status"
+    )
+    termination_date: Optional[date] = Field(
+        default=None,
+        description="Termination date (if applicable)"
+    )
+    location: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Work location"
+    )
+    metadata: Optional[dict] = Field(
+        default=None,
+        description="Additional employee metadata"
+    )
+
+
+class EmployeeResponse(BaseModel):
+    """Schema for employee response."""
+
+    id: str = Field(..., description="Employee unique identifier")
+    org_id: str = Field(..., description="Organization identifier")
+    employee_number: str = Field(..., description="Employee ID/number")
+    first_name: str = Field(..., description="First name")
+    last_name: str = Field(..., description="Last name")
+    email: str = Field(..., description="Email address")
+    phone: Optional[str] = Field(default=None, description="Phone number")
+    department: Optional[str] = Field(default=None, description="Department")
+    job_title: Optional[str] = Field(default=None, description="Job title")
+    manager_id: Optional[str] = Field(default=None, description="Manager's employee ID")
+    employment_type: EmploymentType = Field(..., description="Employment type")
+    employment_status: EmploymentStatus = Field(..., description="Employment status")
+    hire_date: Optional[date] = Field(default=None, description="Hire date")
+    start_date: Optional[date] = Field(default=None, description="Start date")
+    termination_date: Optional[date] = Field(default=None, description="Termination date")
+    location: Optional[str] = Field(default=None, description="Work location")
+    user_id: Optional[str] = Field(default=None, description="Linked user account ID")
+    metadata: dict = Field(default_factory=dict, description="Additional metadata")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    model_config = {"from_attributes": True}
+
+
+class EmployeeListResponse(BaseModel):
+    """Schema for employee list item response."""
+
+    id: str = Field(..., description="Employee unique identifier")
+    employee_number: str = Field(..., description="Employee ID/number")
+    first_name: str = Field(..., description="First name")
+    last_name: str = Field(..., description="Last name")
+    email: str = Field(..., description="Email address")
+    department: Optional[str] = Field(default=None, description="Department")
+    job_title: Optional[str] = Field(default=None, description="Job title")
+    employment_status: EmploymentStatus = Field(..., description="Employment status")
+    created_at: datetime = Field(..., description="Creation timestamp")
+
+    model_config = {"from_attributes": True}
+
+
+class EmployeeSearchQuery(BaseModel):
+    """Schema for employee search query parameters."""
+
+    q: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Search query (name, email, employee number)"
+    )
+    department: Optional[str] = Field(
+        default=None,
+        description="Filter by department"
+    )
+    employment_status: Optional[EmploymentStatus] = Field(
+        default=None,
+        description="Filter by employment status"
+    )
+    employment_type: Optional[EmploymentType] = Field(
+        default=None,
+        description="Filter by employment type"
+    )
+    manager_id: Optional[str] = Field(
+        default=None,
+        description="Filter by manager ID"
+    )

--- a/backend/app/schemas/legal_hold.py
+++ b/backend/app/schemas/legal_hold.py
@@ -1,0 +1,159 @@
+"""Legal hold schemas for DocFlow HR.
+
+Legal holds prevent document deletion during litigation, investigations, or audits.
+When a legal hold is placed, all affected documents are preserved indefinitely
+until the hold is released by authorized personnel (Legal or HR Admin roles).
+
+Legal holds take precedence over retention policies - documents under hold cannot
+be deleted even if their retention period has expired.
+"""
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LegalHoldScope(BaseModel):
+    """Legal hold scope definition."""
+
+    scope_type: Literal["employee", "department", "document_category", "date_range"] = Field(
+        ...,
+        description="Type of scope: employee (specific person), department (entire dept), "
+        "document_category (all docs of a type), or date_range (docs created in period)",
+    )
+    scope_value: str = Field(
+        ...,
+        description="Value for the scope - employee_id, department name, category name, "
+        "or ISO date range (e.g., '2023-01-01:2023-12-31')",
+    )
+
+
+class LegalHoldCreate(BaseModel):
+    """Request schema for creating a legal hold.
+
+    Legal holds should only be created by Legal or HR Admin roles.
+    Reason field should document the legal/compliance basis for the hold
+    (e.g., 'Smith v. Company ABC litigation', 'EEOC investigation #12345').
+    """
+
+    name: str = Field(
+        ...,
+        description="Descriptive name for the legal hold (e.g., 'Smith Litigation 2024')",
+        min_length=3,
+        max_length=200,
+    )
+    scope_type: Literal["employee", "department", "document_category", "date_range"] = Field(
+        ...,
+        description="Scope type determining which documents are affected",
+    )
+    scope_value: str = Field(
+        ...,
+        description="Specific value for the scope type",
+        min_length=1,
+    )
+    reason: Optional[str] = Field(
+        None,
+        description="Legal/compliance reason for the hold (required for audit trail)",
+        max_length=1000,
+    )
+
+
+class LegalHoldUpdate(BaseModel):
+    """Schema for updating legal hold metadata.
+
+    Note: Scope cannot be changed after creation. To modify scope,
+    release the existing hold and create a new one.
+    """
+
+    name: Optional[str] = Field(
+        None,
+        description="Updated descriptive name",
+        min_length=3,
+        max_length=200,
+    )
+    reason: Optional[str] = Field(
+        None,
+        description="Updated reason for the hold",
+        max_length=1000,
+    )
+
+
+class LegalHold(BaseModel):
+    """Legal hold with full metadata.
+
+    Active holds prevent deletion of all documents matching the scope criteria.
+    Released holds are kept for audit trail but no longer block deletions.
+    """
+
+    id: str = Field(..., description="Unique legal hold identifier")
+    org_id: str = Field(..., description="Organization identifier")
+    name: str = Field(..., description="Descriptive name of the legal hold")
+    scope_type: str = Field(..., description="Type of scope applied")
+    scope_value: str = Field(..., description="Specific scope value")
+    reason: Optional[str] = Field(None, description="Legal/compliance reason")
+    status: Literal["active", "released"] = Field(
+        ...,
+        description="Hold status: active (blocking deletions) or released (historical record)",
+    )
+    created_by: str = Field(..., description="User who created the hold")
+    created_at: datetime = Field(..., description="Hold creation timestamp")
+    released_by: Optional[str] = Field(None, description="User who released the hold")
+    released_at: Optional[datetime] = Field(None, description="Hold release timestamp")
+    affected_document_count: int = Field(
+        default=0,
+        description="Number of documents currently affected by this hold",
+    )
+
+    model_config = {"from_attributes": True}
+
+
+class LegalHoldRelease(BaseModel):
+    """Request schema for releasing a legal hold.
+
+    Releasing a hold allows retention policies to resume for affected documents.
+    Only Legal or HR Admin roles can release holds.
+    """
+
+    reason: Optional[str] = Field(
+        None,
+        description="Reason for releasing the hold (e.g., 'Case dismissed', 'Investigation closed')",
+        max_length=500,
+    )
+
+
+class LegalHoldReleaseResponse(BaseModel):
+    """Response schema for legal hold release."""
+
+    legal_hold_id: str = Field(..., description="Released legal hold identifier")
+    name: str = Field(..., description="Name of the released hold")
+    status: str = Field(..., description="New status (should be 'released')")
+    released_by: str = Field(..., description="User who released the hold")
+    released_at: datetime = Field(..., description="Release timestamp")
+    affected_documents: int = Field(
+        ...,
+        description="Number of documents that were under this hold",
+    )
+    message: str = Field(..., description="Status message")
+
+
+class DocumentLegalHoldStatus(BaseModel):
+    """Schema for document's legal hold status.
+
+    Used to check whether a document can be deleted and which holds
+    are currently protecting it.
+    """
+
+    document_id: str = Field(..., description="Document identifier")
+    under_legal_hold: bool = Field(
+        ...,
+        description="Whether document is currently under any legal hold",
+    )
+    active_holds: list[LegalHold] = Field(
+        default_factory=list,
+        description="List of active legal holds affecting this document",
+    )
+    can_be_deleted: bool = Field(
+        ...,
+        description="Whether document can be deleted (false if under hold)",
+    )

--- a/backend/app/schemas/organizations.py
+++ b/backend/app/schemas/organizations.py
@@ -1,0 +1,99 @@
+"""Pydantic schemas for organization management."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field, EmailStr
+
+
+class OrganizationStatus(str, Enum):
+    """Organization status enumeration."""
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    SUSPENDED = "suspended"
+    PENDING = "pending"
+
+
+class OrganizationCreate(BaseModel):
+    """Schema for creating a new organization."""
+
+    name: str = Field(
+        ...,
+        min_length=2,
+        max_length=255,
+        description="Organization name"
+    )
+    slug: Optional[str] = Field(
+        default=None,
+        min_length=2,
+        max_length=100,
+        pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$",
+        description="URL-friendly slug (auto-generated if not provided)"
+    )
+    domain: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Organization's primary email domain"
+    )
+    admin_email: EmailStr = Field(
+        ...,
+        description="Primary admin email address"
+    )
+    settings: Optional[dict] = Field(
+        default_factory=dict,
+        description="Organization-specific settings"
+    )
+
+
+class OrganizationUpdate(BaseModel):
+    """Schema for updating an organization."""
+
+    name: Optional[str] = Field(
+        default=None,
+        min_length=2,
+        max_length=255,
+        description="Organization name"
+    )
+    domain: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Organization's primary email domain"
+    )
+    status: Optional[OrganizationStatus] = Field(
+        default=None,
+        description="Organization status"
+    )
+    settings: Optional[dict] = Field(
+        default=None,
+        description="Organization-specific settings"
+    )
+
+
+class OrganizationResponse(BaseModel):
+    """Schema for organization response."""
+
+    id: str = Field(..., description="Organization unique identifier")
+    name: str = Field(..., description="Organization name")
+    slug: str = Field(..., description="URL-friendly slug")
+    domain: Optional[str] = Field(default=None, description="Primary email domain")
+    admin_email: str = Field(..., description="Primary admin email")
+    status: OrganizationStatus = Field(..., description="Organization status")
+    settings: dict = Field(default_factory=dict, description="Organization settings")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    model_config = {"from_attributes": True}
+
+
+class OrganizationListResponse(BaseModel):
+    """Schema for organization list item response."""
+
+    id: str = Field(..., description="Organization unique identifier")
+    name: str = Field(..., description="Organization name")
+    slug: str = Field(..., description="URL-friendly slug")
+    status: OrganizationStatus = Field(..., description="Organization status")
+    created_at: datetime = Field(..., description="Creation timestamp")
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/retention.py
+++ b/backend/app/schemas/retention.py
@@ -1,0 +1,123 @@
+"""Retention policy schemas for DocFlow HR.
+
+Retention policies define how long employee documents must be retained after
+termination, based on state-specific legal requirements. These policies ensure
+compliance with state record retention laws while enabling automated cleanup
+of outdated records.
+"""
+
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class RetentionPolicyBase(BaseModel):
+    """Base retention policy schema."""
+
+    state_code: str = Field(
+        ...,
+        description="Two-letter state code (e.g., FL, TX, AZ)",
+        min_length=2,
+        max_length=2,
+    )
+    document_category: str = Field(
+        ...,
+        description="Document category this policy applies to",
+    )
+    retention_days: int = Field(
+        ...,
+        description="Number of days to retain documents after termination",
+        ge=0,
+    )
+
+
+class RetentionPolicyCreate(RetentionPolicyBase):
+    """Schema for creating a retention policy."""
+
+    pass
+
+
+class RetentionPolicy(RetentionPolicyBase):
+    """Retention policy with metadata."""
+
+    id: str = Field(..., description="Unique policy identifier")
+    org_id: str = Field(..., description="Organization identifier")
+    created_at: datetime = Field(..., description="Policy creation timestamp")
+    updated_at: Optional[datetime] = Field(None, description="Last update timestamp")
+    created_by: str = Field(..., description="User who created the policy")
+
+    model_config = {"from_attributes": True}
+
+
+class RetentionCalculationRequest(BaseModel):
+    """Request schema for retention date calculation."""
+
+    employee_id: str = Field(..., description="Employee identifier")
+    document_id: str = Field(..., description="Document identifier")
+
+
+class RetentionCalculation(BaseModel):
+    """Retention calculation result.
+
+    This schema provides the calculated deletion date for a document based on:
+    - Employee's state of work
+    - Document category retention policy
+    - Employee termination date
+    - Active legal holds
+    """
+
+    document_id: str = Field(..., description="Document identifier")
+    employee_id: str = Field(..., description="Employee identifier")
+    state_code: str = Field(..., description="Employee's state of work")
+    retention_days: int = Field(
+        ...,
+        description="Number of days from termination to retain document",
+    )
+    termination_date: Optional[date] = Field(
+        None,
+        description="Employee termination date (null if still active)",
+    )
+    deletion_scheduled_at: Optional[datetime] = Field(
+        None,
+        description="Calculated deletion timestamp (null if employee active or under legal hold)",
+    )
+    under_legal_hold: bool = Field(
+        ...,
+        description="Whether document is currently under legal hold (blocks deletion)",
+    )
+    legal_hold_count: int = Field(
+        default=0,
+        description="Number of active legal holds affecting this document",
+    )
+
+
+class RetentionScheduleRequest(BaseModel):
+    """Request schema for scheduling document deletion."""
+
+    document_id: str = Field(..., description="Document identifier")
+    deletion_scheduled_at: datetime = Field(
+        ...,
+        description="Timestamp when document should be deleted",
+    )
+    reason: Optional[str] = Field(
+        None,
+        description="Business justification for scheduling deletion",
+    )
+
+
+class RetentionScheduleResponse(BaseModel):
+    """Response schema for scheduled deletion."""
+
+    document_id: str = Field(..., description="Document identifier")
+    deletion_scheduled_at: datetime = Field(
+        ...,
+        description="Scheduled deletion timestamp",
+    )
+    under_legal_hold: bool = Field(
+        ...,
+        description="Whether document is under legal hold",
+    )
+    scheduled_by: str = Field(..., description="User who scheduled the deletion")
+    scheduled_at: datetime = Field(..., description="When the scheduling occurred")
+    message: str = Field(..., description="Status message")

--- a/backend/app/schemas/review.py
+++ b/backend/app/schemas/review.py
@@ -1,0 +1,78 @@
+"""Review workflow schemas for DocFlow HR API."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ReviewQueueItem(BaseModel):
+    """Individual item in the review queue."""
+
+    document_id: str = Field(description="Unique identifier of the document")
+    employee_name: str = Field(description="Name of the employee who submitted the document")
+    employee_id: str = Field(description="ID of the employee who submitted the document")
+    document_category: str = Field(description="Category of the document")
+    submitted_at: datetime = Field(description="Timestamp when the document was submitted")
+    submission_channel: str = Field(description="Channel through which the document was submitted")
+    document_name: Optional[str] = Field(default=None, description="Name of the document")
+    file_type: Optional[str] = Field(default=None, description="File type/extension")
+
+
+class ReviewQueueResponse(BaseModel):
+    """Paginated response for review queue."""
+
+    items: List[ReviewQueueItem] = Field(description="List of documents pending review")
+    total: int = Field(ge=0, description="Total number of documents pending review")
+    page: int = Field(ge=1, description="Current page number")
+    page_size: int = Field(ge=1, le=100, description="Number of items per page")
+    has_next: bool = Field(description="Whether there is a next page")
+    has_previous: bool = Field(description="Whether there is a previous page")
+
+
+class ApproveRequest(BaseModel):
+    """Request body for approving a document."""
+
+    notes: Optional[str] = Field(
+        default=None,
+        max_length=1000,
+        description="Optional notes from the reviewer"
+    )
+
+
+class RejectRequest(BaseModel):
+    """Request body for rejecting a document."""
+
+    reason: str = Field(
+        min_length=1,
+        max_length=500,
+        description="Reason for rejection"
+    )
+    notes: Optional[str] = Field(
+        default=None,
+        max_length=1000,
+        description="Optional additional notes from the reviewer"
+    )
+
+
+class ReviewResponse(BaseModel):
+    """Response after a review action (approve/reject)."""
+
+    document_id: str = Field(description="ID of the reviewed document")
+    status: str = Field(description="New status of the document")
+    reviewed_by: str = Field(description="ID of the reviewer")
+    reviewed_by_name: Optional[str] = Field(default=None, description="Name of the reviewer")
+    reviewed_at: datetime = Field(description="Timestamp of the review action")
+    notes: Optional[str] = Field(default=None, description="Review notes")
+    rejection_reason: Optional[str] = Field(
+        default=None,
+        description="Reason for rejection (only for rejected documents)"
+    )
+
+
+class ReviewStats(BaseModel):
+    """Statistics about the review queue."""
+
+    pending_count: int = Field(ge=0, description="Number of documents pending review")
+    approved_today: int = Field(ge=0, description="Number of documents approved today")
+    rejected_today: int = Field(ge=0, description="Number of documents rejected today")

--- a/backend/app/schemas/uploads.py
+++ b/backend/app/schemas/uploads.py
@@ -1,0 +1,118 @@
+"""Pydantic schemas for file upload management."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class UploadStatus(str, Enum):
+    """Upload status enumeration."""
+
+    PENDING = "pending"
+    UPLOADING = "uploading"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class UploadType(str, Enum):
+    """Upload type enumeration."""
+
+    DOCUMENT = "document"
+    ATTACHMENT = "attachment"
+    PROFILE_PHOTO = "profile_photo"
+    SIGNATURE = "signature"
+    OTHER = "other"
+
+
+class UploadRequest(BaseModel):
+    """Schema for initiating a file upload."""
+
+    filename: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Original filename"
+    )
+    content_type: str = Field(
+        ...,
+        max_length=100,
+        description="MIME type of the file"
+    )
+    file_size: int = Field(
+        ...,
+        gt=0,
+        le=104857600,  # 100MB max
+        description="File size in bytes"
+    )
+    upload_type: UploadType = Field(
+        default=UploadType.DOCUMENT,
+        description="Type of upload"
+    )
+    folder: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Target folder path"
+    )
+    metadata: Optional[dict] = Field(
+        default_factory=dict,
+        description="Additional upload metadata"
+    )
+
+
+class UploadResponse(BaseModel):
+    """Schema for upload initiation response."""
+
+    id: str = Field(..., description="Upload unique identifier")
+    upload_url: str = Field(..., description="Pre-signed URL for file upload")
+    file_id: str = Field(..., description="File identifier for tracking")
+    expires_at: datetime = Field(..., description="Upload URL expiration")
+    status: UploadStatus = Field(default=UploadStatus.PENDING, description="Upload status")
+    max_file_size: int = Field(..., description="Maximum allowed file size")
+
+    model_config = {"from_attributes": True}
+
+
+class UploadCompleteRequest(BaseModel):
+    """Schema for confirming upload completion."""
+
+    file_id: str = Field(
+        ...,
+        description="File identifier from upload initiation"
+    )
+    checksum: Optional[str] = Field(
+        default=None,
+        description="File checksum for verification"
+    )
+
+
+class UploadCompleteResponse(BaseModel):
+    """Schema for upload completion response."""
+
+    id: str = Field(..., description="Upload unique identifier")
+    file_id: str = Field(..., description="File identifier")
+    status: UploadStatus = Field(..., description="Upload status")
+    file_url: Optional[str] = Field(default=None, description="Accessible file URL")
+    processed_at: Optional[datetime] = Field(default=None, description="Processing timestamp")
+
+    model_config = {"from_attributes": True}
+
+
+class FileMetadata(BaseModel):
+    """Schema for file metadata."""
+
+    id: str = Field(..., description="File unique identifier")
+    org_id: str = Field(..., description="Organization identifier")
+    filename: str = Field(..., description="Original filename")
+    content_type: str = Field(..., description="MIME type")
+    file_size: int = Field(..., description="File size in bytes")
+    upload_type: UploadType = Field(..., description="Type of upload")
+    folder: Optional[str] = Field(default=None, description="Folder path")
+    status: UploadStatus = Field(..., description="Upload status")
+    uploader_id: str = Field(..., description="User who uploaded the file")
+    metadata: dict = Field(default_factory=dict, description="Additional metadata")
+    created_at: datetime = Field(..., description="Upload timestamp")
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -1,0 +1,138 @@
+"""Pydantic schemas for user management."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field, EmailStr
+
+
+class UserRole(str, Enum):
+    """User role enumeration."""
+
+    SUPER_ADMIN = "super_admin"
+    ORG_ADMIN = "org_admin"
+    HR_MANAGER = "hr_manager"
+    HR_USER = "hr_user"
+    EMPLOYEE = "employee"
+    VIEWER = "viewer"
+
+
+class UserStatus(str, Enum):
+    """User status enumeration."""
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    PENDING = "pending"
+    SUSPENDED = "suspended"
+
+
+class UserInviteRequest(BaseModel):
+    """Schema for inviting a new user."""
+
+    email: EmailStr = Field(
+        ...,
+        description="Email address to invite"
+    )
+    role: UserRole = Field(
+        default=UserRole.HR_USER,
+        description="Role to assign to the user"
+    )
+    first_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+        description="User's first name"
+    )
+    last_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+        description="User's last name"
+    )
+    employee_id: Optional[str] = Field(
+        default=None,
+        description="Link to existing employee record"
+    )
+    custom_message: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Custom message to include in invitation email"
+    )
+
+
+class UserInviteResponse(BaseModel):
+    """Schema for user invitation response."""
+
+    id: str = Field(..., description="Invitation unique identifier")
+    user_id: str = Field(..., description="Created user identifier")
+    email: str = Field(..., description="Invited email address")
+    role: UserRole = Field(..., description="Assigned role")
+    status: str = Field(default="pending", description="Invitation status")
+    expires_at: datetime = Field(..., description="Invitation expiration")
+    magic_link_sent: bool = Field(default=True, description="Whether magic link was sent")
+
+    model_config = {"from_attributes": True}
+
+
+class UserActivateRequest(BaseModel):
+    """Schema for activating user via magic link."""
+
+    token: str = Field(
+        ...,
+        min_length=32,
+        description="Magic link activation token"
+    )
+    password: Optional[str] = Field(
+        default=None,
+        min_length=8,
+        max_length=128,
+        description="Optional password to set (if password auth enabled)"
+    )
+
+
+class UserActivateResponse(BaseModel):
+    """Schema for user activation response."""
+
+    id: str = Field(..., description="User unique identifier")
+    email: str = Field(..., description="User email address")
+    role: UserRole = Field(..., description="User role")
+    status: UserStatus = Field(..., description="User status (should be active)")
+    org_id: str = Field(..., description="Organization identifier")
+    access_token: str = Field(..., description="JWT access token")
+    refresh_token: str = Field(..., description="JWT refresh token")
+    activated_at: datetime = Field(..., description="Activation timestamp")
+
+    model_config = {"from_attributes": True}
+
+
+class UserResponse(BaseModel):
+    """Schema for user response."""
+
+    id: str = Field(..., description="User unique identifier")
+    email: str = Field(..., description="User email address")
+    first_name: Optional[str] = Field(default=None, description="First name")
+    last_name: Optional[str] = Field(default=None, description="Last name")
+    role: UserRole = Field(..., description="User role")
+    status: UserStatus = Field(..., description="User status")
+    org_id: str = Field(..., description="Organization identifier")
+    employee_id: Optional[str] = Field(default=None, description="Linked employee record")
+    last_login_at: Optional[datetime] = Field(default=None, description="Last login timestamp")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    model_config = {"from_attributes": True}
+
+
+class UserListResponse(BaseModel):
+    """Schema for user list item response."""
+
+    id: str = Field(..., description="User unique identifier")
+    email: str = Field(..., description="User email address")
+    first_name: Optional[str] = Field(default=None, description="First name")
+    last_name: Optional[str] = Field(default=None, description="Last name")
+    role: UserRole = Field(..., description="User role")
+    status: UserStatus = Field(..., description="User status")
+    created_at: datetime = Field(..., description="Creation timestamp")
+
+    model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- Add base model with common fields (id, timestamps, soft delete)
- Add enums for document types, states, retention categories
- Add organization and user models with roles/permissions
- Add Pydantic schemas for audit, employees, legal hold, retention, review, uploads, and users

## Test plan
- [ ] Verify models import correctly
- [ ] Verify Pydantic schemas validate as expected
- [ ] Run backend type checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)